### PR TITLE
Added uuid field to accounts

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ verify_ssl = true
 pylint = "*"
 pytest = "*"
 pytest-cov = "*"
+mock = "*"
 
 [packages]
 flask = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "583cd39c613174a163ad744a6f6794cebeebde7a8368628a810ab1b00bfe88f1"
+            "sha256": "209b28b6ad663e44ab06c4ded79f220de70361b6f76e8a59d632eceba74c6191"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
@@ -146,6 +146,13 @@
             ],
             "version": "==1.1.6"
         },
+        "funcsigs": {
+            "hashes": [
+                "sha256:330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca",
+                "sha256:a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50"
+            ],
+            "version": "==1.0.2"
+        },
         "isort": {
             "hashes": [
                 "sha256:cd5d3fc2c16006b567a17193edf4ed9830d9454cbeb5a42ac80b36ea00c23db4",
@@ -193,6 +200,20 @@
                 "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
             ],
             "version": "==0.6.1"
+        },
+        "mock": {
+            "hashes": [
+                "sha256:5ce3c71c5545b472da17b72268978914d0252980348636840bd34a00b5cc96c1",
+                "sha256:b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba"
+            ],
+            "version": "==2.0.0"
+        },
+        "pbr": {
+            "hashes": [
+                "sha256:60c25b7dfd054ef9bb0ae327af949dd4676aa09ac3a9471cdc871d8a9213f9ac",
+                "sha256:05f61c71aaefc02d8e37c0a3eeb9815ff526ea28b3b76324769e6158d7f95be1"
+            ],
+            "version": "==3.1.1"
         },
         "py": {
             "hashes": [

--- a/api/api/accounts.py
+++ b/api/api/accounts.py
@@ -2,6 +2,7 @@
     Account: a model of an account in War Torn Faith
     register: registers a blueprint for account operations to a Flask app
 '''
+from uuid import uuid4
 from flask import Blueprint
 
 
@@ -14,11 +15,22 @@ class Account(object):
         username: the player's public identity
     '''
 
-    def __init__(self):
+    def __init__(self, uuid=None, email='', password='', username=''):
         '''Initialize an account'''
-        self._email = ''
-        self._password = ''
-        self._username = ''
+        self._uuid = uuid or uuid4()
+        self._email = email
+        self._password = password
+        self._username = username
+
+    @property
+    def uuid(self):
+        '''Get the account's UUID'''
+        return self._uuid
+
+    @uuid.setter
+    def uuid(self, value):
+        '''Set the account's UUID'''
+        self._uuid = value
 
     @property
     def email(self):

--- a/api/tests/test_accounts.py
+++ b/api/tests/test_accounts.py
@@ -1,16 +1,36 @@
 # pylint: disable=missing-docstring
+from mock import patch
 from api.accounts import Account
 
 
-def test_account_defaults():
+@patch('api.accounts.uuid4')
+def test_account_defaults(uuid4):
+    # stub out uuid4 to return the same uuid for testing purposes
+    uuid4.return_value = '048e8cf5-bf6f-4b39-ac97-6f9851f61b16'
     account = Account()
+    assert account.uuid == '048e8cf5-bf6f-4b39-ac97-6f9851f61b16'
     assert account.email == ''
     assert account.password == ''
     assert account.username == ''
 
 
+def test_account_construction():
+    account = Account(
+        uuid='eebcacc8-b2d4-11e7-abc4-cec278b6b50a',
+        email='foobar@gmail.com',
+        password='foobar123',
+        username='foobar'
+    )
+    assert account.uuid == 'eebcacc8-b2d4-11e7-abc4-cec278b6b50a'
+    assert account.email == 'foobar@gmail.com'
+    assert account.password == 'foobar123'
+    assert account.username == 'foobar'
+
+
 def test_account_setters():
     account = Account()
+    account.uuid = '60d0d4a4-3159-467d-a972-cd8a386931c4'
+    assert account.uuid == '60d0d4a4-3159-467d-a972-cd8a386931c4'
     account.email = 'foobar@gmail.com'
     assert account.email == 'foobar@gmail.com'
     account.password = 'foobar123'


### PR DESCRIPTION
This change adds the `uuid` field to `Account`. If a UUID is not provided when constructing an `Account` object, then one will be automatically generated for the account.

I also added the `mock` module in order to stub out the implementation of `uuid.uuid4()` for testing purposes. The `mock` module will be used frequently in testing going forward.

Resolves #5