### PR TITLE
Added account password hashing and salting

### DIFF
--- a/api/api/accounts.py
+++ b/api/api/accounts.py
@@ -2,6 +2,7 @@
     Account: a model of an account in War Torn Faith
     register: registers a blueprint for account operations to a Flask app
 '''
+from hashlib import sha256
 from uuid import uuid4
 from flask import Blueprint
 
@@ -15,7 +16,7 @@ class Account(object):
         username: the player's public identity
     '''
 
-    def __init__(self, uuid=None, email='', password='', username=''):
+    def __init__(self, uuid=None, email=None, password=None, username=None):
         '''Initialize an account'''
         self._uuid = uuid or uuid4()
         self._email = email
@@ -50,7 +51,7 @@ class Account(object):
     @password.setter
     def password(self, value):
         '''Set the account's password'''
-        self._password = value
+        self._password = salt_and_hash(value)
 
     @property
     def username(self):
@@ -61,6 +62,12 @@ class Account(object):
     def username(self, value):
         '''Set the account's username'''
         self._username = value
+
+
+def salt_and_hash(value):
+    '''Salt and hash a value'''
+    salt = sha256(uuid4())
+    return salt + sha256(salt + value)
 
 
 def get_accounts():

--- a/api/tests/test_accounts.py
+++ b/api/tests/test_accounts.py
@@ -9,9 +9,9 @@ def test_account_defaults(uuid4):
     uuid4.return_value = '048e8cf5-bf6f-4b39-ac97-6f9851f61b16'
     account = Account()
     assert account.uuid == '048e8cf5-bf6f-4b39-ac97-6f9851f61b16'
-    assert account.email == ''
-    assert account.password == ''
-    assert account.username == ''
+    assert account.email is None
+    assert account.password is None
+    assert account.username is None
 
 
 def test_account_construction():
@@ -27,13 +27,22 @@ def test_account_construction():
     assert account.username == 'foobar'
 
 
-def test_account_setters():
+@patch('api.accounts.sha256')
+def test_account_setters(sha256):
+    # stub out sha256 to return the same hashes for testing purposes
+    sha256.side_effect = [
+        '67d765888ea8f71875dfe27334786bffdca070705ee97bd17bec85f8580f7f01',
+        '012eab80b72cbfe663429219e920aee8cd17ba8893e302844682104ee88d3145'
+    ]
     account = Account()
     account.uuid = '60d0d4a4-3159-467d-a972-cd8a386931c4'
     assert account.uuid == '60d0d4a4-3159-467d-a972-cd8a386931c4'
     account.email = 'foobar@gmail.com'
     assert account.email == 'foobar@gmail.com'
     account.password = 'foobar123'
-    assert account.password == 'foobar123'
+    assert account.password == (
+        '67d765888ea8f71875dfe27334786bffdca070705ee97bd17bec85f8580f7f01'
+        + '012eab80b72cbfe663429219e920aee8cd17ba8893e302844682104ee88d3145'
+    )
     account.username = 'foobar'
     assert account.username == 'foobar'


### PR DESCRIPTION
Account passwords will be automatically salted and hashed if they are set using the password setter. If passwords are passed to the account during construction, it is assumed that they are already hashed.

Also, made the default values for `email`, `password`, and `username` all `None` instead of an empty string.

Resolves #8