### PR TITLE
Fixed pytest-cov not getting installed in Windows (hopefully)

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ verify_ssl = true
 [dev-packages]
 pylint = "*"
 pytest = "*"
-pytest-cov = "*"
+"pytest-cov" = "*"
 mock = "*"
 
 [packages]


### PR DESCRIPTION
Apparently just quoting `pytest-cov` resolves this issue