### PR TITLE
Added account equality operators, refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ __pycache__
 # coverage data
 .coverage
 htmlcov
+
+# junk
+.DS_Store
+

--- a/api/api/util.py
+++ b/api/api/util.py
@@ -1,0 +1,9 @@
+'''API utilities'''
+from hashlib import sha256
+from uuid import uuid4
+
+def salt_and_hash(value, salt=None):
+    '''Salt and hash a value'''
+    if salt is None:
+        salt = sha256(uuid4().bytes).hexdigest()
+    return salt + sha256(str.encode(salt + value)).hexdigest()

--- a/api/tests/test_util.py
+++ b/api/tests/test_util.py
@@ -1,0 +1,13 @@
+# pylint: disable=missing-docstring,invalid-name
+from mock import patch, Mock
+from api import util
+
+@patch('api.util.sha256')
+def test_salt_and_hash_no_salt(mock_sha256):
+    # stub out sha256 to return the same hashes for testing purposes
+    hash1 = Mock()
+    hash1.hexdigest = Mock(return_value='foo')
+    hash2 = Mock()
+    hash2.hexdigest = Mock(return_value='bar')
+    mock_sha256.side_effect = [hash1, hash2]
+    assert util.salt_and_hash('asdf') == 'foobar'


### PR DESCRIPTION
- Added account equality operators
  - You can now compare two account objects with `==` and `!=`
- Moved `salt_and_has()` utility to a new `util.py` module
- Renamed `authenticate()` in `AccountRepository` to `find_by_email_password()`, which should be a much more semantically correct function to find in a Repository
- General refactoring, mostly concerning the unit tests and test data

Resolves #24