### PR TITLE
Added initial Vagrantfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ __pycache__
 .coverage
 htmlcov
 
+# vagrant stuff
+.vagrant/
+
 # junk
 .DS_Store
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,11 @@ For more help with pipenv:
 $ pipenv --help
 ```
 
+To use [Vagrant](https://www.vagrantup.com/):
+```bash
+$ vagrant up & vagrant ssh
+```
+
 ## developing
 
 **Note:** It's easier to work from the subshell created by `pipenv shell`. If you use `pipenv shell`, you can omit `pipenv run` in the commands below.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,32 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version. Please don't change it unless you know what
+# you're doing.
+VAGRANTFILE_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_VERSION) do |config|
+
+  config.vm.box = "ubuntu/trusty64"
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  config.vm.network "forwarded_port", guest: 5000, host: 5000
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Enable provisioning with a shell script. Updates & Installs pip and pipenv.
+  config.vm.provision "shell", inline: <<-SHELL
+    apt-get update
+    curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
+    python3 get-pip.py
+    pip3 install pipenv
+  SHELL
+end


### PR DESCRIPTION
Adds the initial Vagrantfile.

To run:
1. install [vagrant](https://www.vagrantup.com/downloads.html)
2. open a terminal and navigate to the project root
3. provision and start vagrant: `vagrant up`
4. ssh into the vm: `vagrant ssh`
5. `cd /vagrant` to navigate to the project directory

Now you can develop on your host machine and run the app & api in the vm. We should also look into adding other cool features, such as [*synced folders*](https://www.vagrantup.com/docs/synced-folders/) or creating an [*external provision script*](https://www.vagrantup.com/docs/provisioning/shell.html#external-script).

**NOTE:** To hit the API from host machine start the Flask app using the following cmd:
`FLASK_APP=api/app.py pipenv run flask run --host 0.0.0.0`

resolves #30 