### PR TITLE
Migrate tests alongside code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ install:
   - pipenv install --dev
 script:
   - pipenv run pylint api/api
-  - pipenv run pylint api/tests
   - pipenv run pytest
 branches:
   only:

--- a/api/api/test_accounts.py
+++ b/api/api/test_accounts.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-docstring,invalid-name,redefined-outer-name
 import pytest
 from mock import patch
-from api.accounts import IN_MEMORY_ACCOUNTS, Account, AccountRepository
+from .accounts import IN_MEMORY_ACCOUNTS, Account, AccountRepository
 
 
 TEST_EMAIL = 'foobar@gmail.com'

--- a/api/api/test_util.py
+++ b/api/api/test_util.py
@@ -1,6 +1,6 @@
 # pylint: disable=missing-docstring,invalid-name
 from mock import patch, Mock
-from api import util
+from . import util
 
 @patch('api.util.sha256')
 def test_salt_and_hash_no_salt(mock_sha256):

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,4 +3,4 @@ addopts =
   --cov=api/api
   --cov-report=term-missing
   --cov-report=html
-testpaths = api/tests
+testpaths = api/api


### PR DESCRIPTION
Removed the `/tests` folder and moved tests alongside code.

I think we should consider having the tests placed in a `/test` folder in each module. This is so we can isolate the code from the tests inside each module.  We can reference this [pytest doc](https://docs.pytest.org/en/latest/goodpractices.html#tests-as-part-of-application-code)

resolves #29 