### PR TITLE
Implemented weapon recipe creation

### DIFF
--- a/wtf/api/characters.py
+++ b/wtf/api/characters.py
@@ -110,7 +110,7 @@ def find_by_account_id(account_id):
 
 
 def create(**kwargs):
-    '''Create an character.
+    '''Create a character.
 
     Characters have the following properties:
         id: a UUID (Universally Unique Identifier) for the character

--- a/wtf/api/weaponrecipes.py
+++ b/wtf/api/weaponrecipes.py
@@ -1,0 +1,48 @@
+'''
+wtf.api.weaponrecipes
+
+Routes and functions for manipulating weapon recipes.
+'''
+
+
+def create(**kwargs):
+    '''Create a weapon recipe.
+
+    Weapon recipes have the following properties:
+        name: the name of the weapon
+        description: a description of the weapon
+        weight: how much the weapon weighs
+            center: the center of the weapon's weight interval
+            radius: the radius of the weapon's weight interval
+        damage: how much damage the weapon can inflict
+            min: the minimum amount of damage the weapon can inflict
+                center: the center of the weapon's minimum damage interval
+                radius: the radius of the weapon's minimum damage interval
+            max: the maximum amount of damage the weapon can inflict
+                center: the center of the weapon's maximum damage interval
+                radius: the radius of the weapon's maximum damage interval
+    '''
+    name = kwargs.get('name')
+    description = kwargs.get('description')
+    weight = kwargs.get('weight', {})
+    damage = kwargs.get('damage', {})
+    damage_min = damage.get('min', {})
+    damage_max = damage.get('max', {})
+    return {
+        'name': name,
+        'description': description,
+        'weight': {
+            'center': weight.get('center', 0),
+            'radius': weight.get('radius', 0)
+        },
+        'damage': {
+            'min': {
+                'center': damage_min.get('center', 0),
+                'radius': damage_min.get('radius', 0)
+            },
+            'max': {
+                'center': damage_max.get('center', 0),
+                'radius': damage_max.get('radius', 0)
+            }
+        }
+    }

--- a/wtf/api/weaponrecipes_test.py
+++ b/wtf/api/weaponrecipes_test.py
@@ -1,0 +1,38 @@
+# pylint: disable=missing-docstring,invalid-name,redefined-outer-name
+from wtf.api import weaponrecipes
+
+
+def test_create():
+    expected = {
+        'name': 'foobar',
+        'description': 'foo bar baz',
+        'weight': {'center': 12, 'radius': 3},
+        'damage': {
+            'min': {'center': 45, 'radius': 6},
+            'max': {'center': 78, 'radius': 9}
+        }
+    }
+    actual = weaponrecipes.create(
+        name='foobar',
+        description='foo bar baz',
+        weight=dict(center=12, radius=3),
+        damage=dict(
+            min=dict(center=45, radius=6),
+            max=dict(center=78, radius=9)
+        )
+    )
+    assert expected == actual
+
+
+def test_create_defaults():
+    expected = {
+        'name': None,
+        'description': None,
+        'weight': {'center': 0, 'radius': 0},
+        'damage': {
+            'min': {'center': 0, 'radius': 0},
+            'max': {'center': 0, 'radius': 0}
+        }
+    }
+    actual = weaponrecipes.create()
+    assert expected == actual


### PR DESCRIPTION
Added a `wtf/api/weaponrecipes.py` module and a `create()` function to create new weapon recipes.

Part of #52