### PR TITLE
Fixed issue with account retrieval endpoint deleting passwords

### DIFF
--- a/wtf/api/accounts.py
+++ b/wtf/api/accounts.py
@@ -57,7 +57,8 @@ def route_get(account_id):
     account = IN_MEMORY_ACCOUNTS.get('by_id').get(account_id)
     response = None
     if account:
-        account.pop('password')
+        account = account.copy()
+        pwd = account.pop('password')
         response = http.success(json={'account': account})
     else:
         response = http.not_found(json={'errors': ['Account not found']})

--- a/wtf/api/accounts.py
+++ b/wtf/api/accounts.py
@@ -58,7 +58,7 @@ def route_get(account_id):
     response = None
     if account:
         account = account.copy()
-        pwd = account.pop('password')
+        account.pop('password')
         response = http.success(json={'account': account})
     else:
         response = http.not_found(json={'errors': ['Account not found']})

--- a/wtf/api/accounts_test.py
+++ b/wtf/api/accounts_test.py
@@ -71,6 +71,9 @@ def test_accounts_route_get_by_id(test_client):
     response = test_client.get(path='/%s' % TEST_ID)
     response.assert_status_code(200)
     response.assert_body(expected)
+    response = test_client.get(path='/%s' % TEST_ID)
+    response.assert_status_code(200)
+    response.assert_body(expected)
 
 
 def test_accounts_route_get_by_id_not_found(test_client):


### PR DESCRIPTION
Found this issue when playing around with the accounts endpoint.

This will add the logic to create a copy of the account dictionary returned. This is so it doesn't alter the original in memory object.

Fixes: #64 