### PR TITLE
Added weapon recipe API endpoints

### DIFF
--- a/wtf/api/__init__.py
+++ b/wtf/api/__init__.py
@@ -6,14 +6,15 @@ The War Torn Faith RESTful API is a Flask application that exposes the
     designed to be consumed by War Torn Faith's web app, third-party consumption
     is also a possibility.
 '''
-from wtf.api import accounts, characters, errors, health
+from wtf.api import accounts, characters, errors, health, weaponrecipes
 
 
-API_URL_PREFIX = '/api'
+API_PREFIX = '/api'
 API_BLUEPRINTS = [
     ('/accounts', accounts.BLUEPRINT),
     ('/characters', characters.BLUEPRINT),
-    ('/health', health.BLUEPRINT)
+    ('/health', health.BLUEPRINT),
+    ('/weapon-recipes', weaponrecipes.BLUEPRINT)
 ]
 API_ERROR_HANDLERS = [
     (errors.ValidationError, errors.handle_invalid_request),

--- a/wtf/api/accounts.py
+++ b/wtf/api/accounts.py
@@ -14,7 +14,7 @@ REPO = {'by_id': {}, 'by_email': {}}
 
 
 @BLUEPRINT.route('', methods=['POST'])
-def handle_create_request():
+def handle_post_request():
     '''Handle account creation requests.
 
     $ curl \

--- a/wtf/api/app.py
+++ b/wtf/api/app.py
@@ -4,10 +4,10 @@ wtf.api.app
 The War Torn Faith API app.
 '''
 from flask import Flask
-from wtf.api import API_BLUEPRINTS, API_ERROR_HANDLERS, API_URL_PREFIX
+from wtf.api import API_BLUEPRINTS, API_ERROR_HANDLERS, API_PREFIX
 
 
-def create_app(prefix=API_URL_PREFIX):
+def create_app(prefix=API_PREFIX):
     '''Create the API Flask application'''
     app = Flask(__name__)
     for path, blueprint in API_BLUEPRINTS:

--- a/wtf/api/characters.py
+++ b/wtf/api/characters.py
@@ -14,7 +14,7 @@ REPO = {'by_id': {}, 'by_account': {}}
 
 
 @BLUEPRINT.route('', methods=['POST'])
-def handle_create_request():
+def handle_post_request():
     '''Handle character creation requests.
 
     $ curl \

--- a/wtf/api/characters_test.py
+++ b/wtf/api/characters_test.py
@@ -130,7 +130,6 @@ def test_find_character_by_id_not_found():
     assert str(e.value) == 'Character not found'
 
 
-
 def test_find_characters_by_account():
     expected = ['one', 'two', 'three']
     by_account = characters.REPO['by_account']

--- a/wtf/api/health.py
+++ b/wtf/api/health.py
@@ -10,7 +10,7 @@ BLUEPRINT = Blueprint('health', __name__)
 
 
 @BLUEPRINT.route('', methods=['GET'])
-def handle_healthcheck_request():
+def handle_get_request():
     '''Handle healthcheck requests.
 
     $ curl \

--- a/wtf/app.py
+++ b/wtf/app.py
@@ -5,7 +5,7 @@ The War Torn Faith bundled app.
 '''
 from flask import Flask
 from werkzeug.wsgi import DispatcherMiddleware
-from wtf.api import API_URL_PREFIX
+from wtf.api import API_PREFIX
 from wtf.api.app import create_app as create_api_app
 from wtf.web.app import create_app as create_web_app
 
@@ -15,6 +15,6 @@ def create_app():
     app = Flask(__name__)
     app.wsgi_app = DispatcherMiddleware(
         create_web_app(),
-        {API_URL_PREFIX: create_api_app(prefix='')}
+        {API_PREFIX: create_api_app(prefix='')}
     )
     return app


### PR DESCRIPTION
Changes:
- Added `POST /api/weapon-recipes`
- Added `GET /api/weapon-recipes/<id>`
- Renamed `wtf.api.API_URL_PREFIX` to just `wtf.api.API_PREFIX`

I also changed things up with the way I'm managing the test data in the tests for the `weaponrecipes.py` module - all of the (happy path) test data is under a `TEST_DATA` dictionary. We can decide whether this is the convention we want to follow ;)

Part of #52