### PR TITLE
Fixed not found error when creating account

### DIFF
--- a/wtf/api/accounts.py
+++ b/wtf/api/accounts.py
@@ -76,8 +76,12 @@ def validate(account):
     errors = []
     if not email:
         errors.append('Missing required field: email')
-    elif find_by_email(email) is not None:
-        errors.append('Email address already registered')
+    else:
+        try:
+            find_by_email(email)
+            errors.append('Email address already registered')
+        except NotFoundError:
+            pass
     if not password:
         errors.append('Missing required field: password')
     if errors:

--- a/wtf/api/accounts_test.py
+++ b/wtf/api/accounts_test.py
@@ -30,14 +30,8 @@ def test_client():
 
 
 @patch('wtf.api.accounts.save')
-@patch('wtf.api.accounts.find_by_email')
-def test_handle_create_account_request(
-        mock_find_by_email,
-        mock_save,
-        test_client
-    ):
+def test_handle_post_account_request(mock_save, test_client):
     expected = 'foobar'
-    mock_find_by_email.return_value = None
     mock_save.return_value = expected
     response = test_client.post(
         body={'email': TEST_EMAIL, 'password': TEST_PASSWORD_PLAIN}
@@ -46,7 +40,7 @@ def test_handle_create_account_request(
     response.assert_body(expected)
 
 
-def test_handle_create_account_request_content_type_not_json(test_client):
+def test_handle_post_account_request_content_type_not_json(test_client):
     response = test_client.post(headers={'Content-Type': 'text/html'})
     response.assert_status_code(400)
     response.assert_body({
@@ -55,7 +49,7 @@ def test_handle_create_account_request_content_type_not_json(test_client):
 
 
 @patch('wtf.api.accounts.validate')
-def test_handle_create_account_request_invalid(mock_validate, test_client):
+def test_handle_post_account_request_invalid(mock_validate, test_client):
     mock_validate.side_effect = ValidationError(
         errors=['foo', 'bar', 'baz']
     )
@@ -109,6 +103,15 @@ def test_save_account_update(mock_validate):
     assert expected == actual
     assert expected == by_id[TEST_ID]
     assert expected == by_email[TEST_EMAIL]
+
+
+@patch('wtf.api.accounts.find_by_email')
+def test_validate_account(mock_find_by_email):
+    mock_find_by_email.side_effect = NotFoundError('foo bar baz')
+    accounts.validate({
+        'email': TEST_EMAIL,
+        'password': TEST_PASSWORD_PLAIN
+    })
 
 
 def test_validate_account_missing_fields():

--- a/wtf/api/characters_test.py
+++ b/wtf/api/characters_test.py
@@ -26,7 +26,7 @@ def test_client():
 
 @patch('wtf.api.characters.save')
 @patch('wtf.api.characters.find_by_account')
-def test_handle_create_character_request(
+def test_handle_post_character_request(
         mock_find_by_account,
         mock_save,
         test_client
@@ -41,7 +41,7 @@ def test_handle_create_character_request(
     response.assert_body(expected)
 
 
-def test_handle_create_character_request_content_type_not_json(test_client):
+def test_handle_post_character_request_content_type_not_json(test_client):
     response = test_client.post(headers={'Content-Type': 'text/html'})
     response.assert_status_code(400)
     response.assert_body({
@@ -50,7 +50,7 @@ def test_handle_create_character_request_content_type_not_json(test_client):
 
 
 @patch('wtf.api.characters.validate')
-def test_handle_create_character_request_invalid(mock_validate, test_client):
+def test_handle_post_character_request_invalid(mock_validate, test_client):
     mock_validate.side_effect = ValidationError(
         errors=['foo', 'bar', 'baz']
     )

--- a/wtf/api/weaponrecipes_test.py
+++ b/wtf/api/weaponrecipes_test.py
@@ -34,7 +34,7 @@ def test_client():
 
 
 @patch('wtf.api.weaponrecipes.save')
-def test_handle_create_character_request(mock_save, test_client):
+def test_handle_post_character_request(mock_save, test_client):
     expected = 'foobar'
     mock_save.return_value = 'foobar'
     response = test_client.post(
@@ -63,7 +63,7 @@ def test_handle_create_character_request(mock_save, test_client):
     response.assert_body(expected)
 
 
-def test_handle_create_weapon_recipe_request_content_type_not_json(test_client):
+def test_handle_post_weapon_recipe_request_content_type_not_json(test_client):
     response = test_client.post(headers={'Content-Type': 'text/html'})
     response.assert_status_code(400)
     response.assert_body({


### PR DESCRIPTION
After adding a `NotFoundError` to `accounts.find_by_email`, I forgot to check for this error in `accounts.validation`.

Thanks for spotting this @njgrisafi!