### PR TITLE
Improved handling of JSON request body errors

### DIFF
--- a/wtf/api/accounts.py
+++ b/wtf/api/accounts.py
@@ -7,7 +7,7 @@ Accounts have the following properties:
   * password: the password used to authenticate as the account
 '''
 from uuid import uuid4
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify
 from wtf.api import util
 from wtf.api.errors import NotFoundError, ValidationError
 
@@ -30,8 +30,7 @@ def handle_post_request():
             "password": "..."
         }'
     '''
-    util.validate_request(content_type='application/json')
-    body = request.get_json(silent=True) or {}
+    body = util.get_json_body()
     account = save(create(
         email=body.get('email'),
         password=body.get('password')

--- a/wtf/api/accounts.py
+++ b/wtf/api/accounts.py
@@ -49,9 +49,7 @@ def handle_get_by_id_request(account_id):
         --write-out "\n"
     '''
     account = find_by_id(account_id)
-    account = account.copy()
-    account.pop('password')
-    return jsonify({'account': account}), 200
+    return jsonify({'account': transform(account)}), 200
 
 
 def create(**kwargs):
@@ -64,6 +62,17 @@ def create(**kwargs):
         'email': email,
         'password': util.salt_and_hash(password) if password else None
     }
+
+
+def transform(account):
+    '''Transform account fields.
+
+    The following transformations will be performed:
+      * password: removed
+    '''
+    account = account.copy()
+    account.pop('password')
+    return account
 
 
 def save(account):

--- a/wtf/api/accounts_test.py
+++ b/wtf/api/accounts_test.py
@@ -35,23 +35,15 @@ def test_client():
 @patch('wtf.api.accounts.save')
 def test_handle_post_account_request(mock_save, test_client):
     mock_save.return_value = 'foobar'
-    response = test_client.post()
+    response = test_client.post(body={})
     response.assert_status_code(201)
     response.assert_body({'account': 'foobar'})
-
-
-def test_handle_post_account_request_content_type_not_json(test_client):
-    response = test_client.post(headers={'Content-Type': 'text/html'})
-    response.assert_status_code(400)
-    response.assert_body({
-        'errors': ['Content-Type header must be: application/json']
-    })
 
 
 @patch('wtf.api.accounts.save')
 def test_handle_post_account_request_invalid(mock_save, test_client):
     mock_save.side_effect = ValidationError(errors=['foo', 'bar', 'baz'])
-    response = test_client.post()
+    response = test_client.post(body={})
     response.assert_status_code(400)
     response.assert_body({'errors': ['foo', 'bar', 'baz']})
 

--- a/wtf/api/characters.py
+++ b/wtf/api/characters.py
@@ -16,7 +16,7 @@ Characters have the following properties:
     * accuracy: increases normal and critical attack chance
 '''
 from uuid import uuid4
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify
 from wtf.api import util
 from wtf.api.errors import NotFoundError, ValidationError
 
@@ -39,8 +39,7 @@ def handle_post_request():
             "name": "..."
         }'
     '''
-    util.validate_request(content_type='application/json')
-    body = request.get_json(silent=True) or {}
+    body = util.get_json_body()
     character = save(create(
         account=body.get('account'),
         name=body.get('name')
@@ -112,7 +111,7 @@ def save(character):
     '''
     character = character.copy()
     if character.get('id') is None:
-        character['id'] = uuid4()
+        character['id'] = str(uuid4())
     validate(character)
     REPO.get('by_id')[character.get('id')] = character
     REPO.get('by_account') \

--- a/wtf/api/characters_test.py
+++ b/wtf/api/characters_test.py
@@ -29,28 +29,15 @@ def test_client():
 @patch('wtf.api.characters.save')
 def test_handle_post_character_request(mock_save, test_client):
     mock_save.return_value = 'foobar'
-    response = test_client.post()
+    response = test_client.post(body={})
     response.assert_status_code(201)
     response.assert_body({'character': 'foobar'})
 
 
 @patch('wtf.api.characters.save')
-def test_handle_post_character_request_content_type_not_json(
-        mock_save,
-        test_client
-    ):
-    response = test_client.post(headers={'Content-Type': 'text/html'})
-    response.assert_status_code(400)
-    response.assert_body({
-        'errors': ['Content-Type header must be: application/json']
-    })
-    mock_save.assert_not_called()
-
-
-@patch('wtf.api.characters.save')
 def test_handle_post_character_request_invalid(mock_save, test_client):
     mock_save.side_effect = ValidationError(errors=['foo', 'bar', 'baz'])
-    response = test_client.post()
+    response = test_client.post(body={})
     response.assert_status_code(400)
     response.assert_body({'errors': ['foo', 'bar', 'baz']})
 

--- a/wtf/api/util.py
+++ b/wtf/api/util.py
@@ -6,6 +6,7 @@ Miscellaneous utilities.
 from hashlib import sha256
 from uuid import uuid4
 from flask import request
+from werkzeug.exceptions import BadRequest
 from wtf.api.errors import ValidationError
 
 
@@ -22,16 +23,17 @@ def salt_and_hash_compare(plaintext, value):
     return salt_and_hash(plaintext, value[:64]) == value
 
 
-def validate_request(content_type=None):
-    '''Validate an HTTP request.
-
-    Returns a list of validation errors, if any.
-    '''
-    errors = []
-    if content_type and request.content_type != content_type:
-        errors.append('Content-Type header must be: %s' % content_type)
-    if errors:
-        raise ValidationError(errors=errors)
+def get_json_body():
+    '''Get the JSON request body.'''
+    body = None
+    if request.content_type != 'application/json':
+        raise ValidationError('Content-Type header must be: application/json')
+    else:
+        try:
+            body = request.get_json()
+        except BadRequest:
+            raise ValidationError('Unable to parse JSON request body')
+    return body
 
 
 def interval_intersect(interval_1, interval_2):

--- a/wtf/api/util_test.py
+++ b/wtf/api/util_test.py
@@ -1,5 +1,9 @@
 # pylint: disable=missing-docstring,invalid-name
+import pytest
+from mock import Mock, patch
+from werkzeug.exceptions import BadRequest
 from wtf.api import util
+from wtf.api.errors import ValidationError
 
 
 def test_salt_and_hash():
@@ -8,3 +12,24 @@ def test_salt_and_hash():
     salt = salt_hash[:64]
     assert util.salt_and_hash('asdf', salt) == salt_hash
     assert util.salt_and_hash_compare('asdf', salt_hash)
+
+
+@patch('wtf.api.util.request')
+def test_get_json_body_content_type_not_json(mock_request):
+    expected = 'Content-Type header must be: application/json'
+    mock_request.content_type = 'application/html'
+    with pytest.raises(ValidationError) as e:
+        util.get_json_body()
+    actual = e.value.errors
+    assert expected in actual
+
+
+@patch('wtf.api.util.request')
+def test_get_json_body_invalid(mock_request):
+    expected = 'Unable to parse JSON request body'
+    mock_request.content_type = 'application/json'
+    mock_request.get_json = Mock(side_effect=BadRequest())
+    with pytest.raises(ValidationError) as e:
+        util.get_json_body()
+    actual = e.value.errors
+    assert expected in actual

--- a/wtf/api/weaponrecipes.py
+++ b/wtf/api/weaponrecipes.py
@@ -137,9 +137,9 @@ def save(recipe):
     Raises a ValidationError if the recipe is invalid.
     '''
     recipe = recipe.copy()
-    validate(recipe)
     if recipe.get('id') is None:
         recipe['id'] = uuid4()
+    validate(recipe)
     REPO.get('by_id')[recipe.get('id')] = recipe
     return recipe
 
@@ -204,6 +204,7 @@ def validate_damage(recipe):
     Raises a ValidationError if the recipe's damage fields are invalid.
     '''
     errors = []
+    recipe_id = recipe.get('id')
     damage = recipe.get('damage', {})
     damage_min = damage.get('min', {})
     damage_min_center = damage_min.get('center')
@@ -211,6 +212,8 @@ def validate_damage(recipe):
     damage_max = damage.get('max', {})
     damage_max_center = damage_max.get('center')
     damage_max_radius = damage_max.get('radius')
+    if recipe_id is None:
+        errors.append('Missing required field: id')
     if None in [damage_min_center, damage_min_radius]:
         if damage_min_center is None:
             errors.append('Missing required field: damage.min.center')

--- a/wtf/api/weaponrecipes.py
+++ b/wtf/api/weaponrecipes.py
@@ -21,7 +21,7 @@ Weapon recipes have the following properties:
     > maximum damage.max = damage.max.center + damage.max.radius
 '''
 from uuid import uuid4
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify
 from wtf.api import util
 from wtf.api.errors import NotFoundError, ValidationError
 
@@ -61,8 +61,7 @@ def handle_post_request():
             }
         }'
     '''
-    util.validate_request(content_type='application/json')
-    body = request.get_json(silent=True) or {}
+    body = util.get_json_body()
     weight = body.get('weight', {})
     damage = body.get('damage', {})
     damage_min = damage.get('min', {})
@@ -138,7 +137,7 @@ def save(recipe):
     '''
     recipe = recipe.copy()
     if recipe.get('id') is None:
-        recipe['id'] = uuid4()
+        recipe['id'] = str(uuid4())
     validate(recipe)
     REPO.get('by_id')[recipe.get('id')] = recipe
     return recipe

--- a/wtf/api/weaponrecipes_test.py
+++ b/wtf/api/weaponrecipes_test.py
@@ -34,19 +34,19 @@ def test_client():
 
 
 @patch('wtf.api.weaponrecipes.save')
-def test_handle_post_character_request(mock_save, test_client):
+def test_handle_post_weaponrecipe_request(mock_save, test_client):
     mock_save.return_value = 'foobar'
-    response = test_client.post()
+    response = test_client.post(body={})
     response.assert_status_code(201)
     response.assert_body({'recipe': 'foobar'})
 
 
-def test_handle_post_weapon_recipe_request_content_type_not_json(test_client):
-    response = test_client.post(headers={'Content-Type': 'text/html'})
+@patch('wtf.api.weaponrecipes.save')
+def test_handle_post_weapon_recipe_request_invalid(mock_save, test_client):
+    mock_save.side_effect = ValidationError(errors=['foo', 'bar', 'baz'])
+    response = test_client.post(body={})
     response.assert_status_code(400)
-    response.assert_body({
-        'errors': ['Content-Type header must be: application/json']
-    })
+    response.assert_body({'errors': ['foo', 'bar', 'baz']})
 
 
 @patch('wtf.api.weaponrecipes.find_by_id')

--- a/wtf/api/weaponrecipes_test.py
+++ b/wtf/api/weaponrecipes_test.py
@@ -153,6 +153,7 @@ def test_save_weapon_recipe_invalid(mock_validate):
 
 def test_validate_weapon_recipe():
     weaponrecipes.validate({
+        'id': TEST_DATA['id'],
         'type': TEST_DATA['type'],
         'name': TEST_DATA['name'],
         'description': TEST_DATA['description'],
@@ -176,6 +177,7 @@ def test_validate_weapon_recipe():
 
 def test_validate_weapon_recipe_missing_fields():
     expected = [
+        'Missing required field: id',
         'Missing required field: type',
         'Missing required field: name',
         'Missing required field: description',

--- a/wtf/api/weapons.py
+++ b/wtf/api/weapons.py
@@ -38,7 +38,7 @@ def handle_post_request():
     weapon = save(create(
         recipe=body.get('recipe')
     ))
-    return jsonify({'weapon': derive(weapon)}), 201
+    return jsonify({'weapon': transform(weapon)}), 201
 
 
 @BLUEPRINT.route('/<weapon_id>', methods=['GET'])
@@ -51,7 +51,7 @@ def handle_get_request(weapon_id):
         --write-out "\n"
     '''
     weapon = find_by_id(weapon_id)
-    return jsonify({'weapon': derive(weapon)}), 200
+    return jsonify({'weapon': transform(weapon)}), 200
 
 
 def create(**kwargs):
@@ -69,15 +69,23 @@ def generate_grade():
     return random.uniform(0.0, 1.0)
 
 
-def derive(weapon):
-    '''Derive weapon field values.'''
+def transform(weapon):
+    '''Transform weapon fields.
+
+    The following transformations will be performed:
+      * name and description: defaulted to recipe values if None
+      * grade: replaced with +0 to +9 form
+      * weight: derived from recipe and grade
+      * damage.min: derived from recipe and grade
+      * damage.max: derived from recipe and grade
+    '''
     weapon = weapon.copy()
     recipe = weaponrecipes.find_by_id(weapon.get('recipe'))
     if not weapon.get('name'):
         weapon['name'] = recipe.get('name')
     if not weapon.get('description'):
         weapon['description'] = recipe.get('description')
-    grade = weapon.pop('grade')
+    grade = weapon.get('grade')
     weapon['grade'] = '+%s' % int(grade * 10)
     weapon['weight'] = util.interval_grade_value(
         recipe.get('weight'),

--- a/wtf/api/weapons.py
+++ b/wtf/api/weapons.py
@@ -11,7 +11,7 @@ Weapons have the following properties:
 '''
 import random
 from uuid import uuid4
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify
 from wtf.api import util, weaponrecipes
 from wtf.api.errors import NotFoundError, ValidationError
 
@@ -33,8 +33,7 @@ def handle_post_request():
             "recipe": "...",
         }'
     '''
-    util.validate_request(content_type='application/json')
-    body = request.get_json(silent=True) or {}
+    body = util.get_json_body()
     weapon = save(create(
         recipe=body.get('recipe')
     ))

--- a/wtf/api/weapons_test.py
+++ b/wtf/api/weapons_test.py
@@ -38,28 +38,15 @@ def test_client():
 def test_handle_post_weapon_request(mock_save, mock_transform, test_client):
     mock_save.return_value = 'foobar'
     mock_transform.return_value = 'foobar-transformd'
-    response = test_client.post()
+    response = test_client.post(body={})
     response.assert_status_code(201)
     response.assert_body({'weapon': 'foobar-transformd'})
 
 
 @patch('wtf.api.weapons.save')
-def test_handle_post_weapon_request_content_type_not_json(
-        mock_save,
-        test_client
-    ):
-    response = test_client.post(headers={'Content-Type': 'text/html'})
-    response.assert_status_code(400)
-    response.assert_body(
-        {'errors': ['Content-Type header must be: application/json']}
-    )
-    mock_save.assert_not_called()
-
-
-@patch('wtf.api.weapons.save')
 def test_handle_post_weapon_request_invalid(mock_save, test_client):
     mock_save.side_effect = ValidationError(errors=['foo', 'bar', 'baz'])
-    response = test_client.post()
+    response = test_client.post(body={})
     response.assert_status_code(400)
     response.assert_body({'errors': ['foo', 'bar', 'baz']})
 

--- a/wtf/api/weapons_test.py
+++ b/wtf/api/weapons_test.py
@@ -33,14 +33,14 @@ def test_client():
     return client
 
 
-@patch('wtf.api.weapons.derive')
+@patch('wtf.api.weapons.transform')
 @patch('wtf.api.weapons.save')
-def test_handle_post_weapon_request(mock_save, mock_derive, test_client):
+def test_handle_post_weapon_request(mock_save, mock_transform, test_client):
     mock_save.return_value = 'foobar'
-    mock_derive.return_value = 'foobar-derived'
+    mock_transform.return_value = 'foobar-transformd'
     response = test_client.post()
     response.assert_status_code(201)
-    response.assert_body({'weapon': 'foobar-derived'})
+    response.assert_body({'weapon': 'foobar-transformd'})
 
 
 @patch('wtf.api.weapons.save')
@@ -64,18 +64,18 @@ def test_handle_post_weapon_request_invalid(mock_save, test_client):
     response.assert_body({'errors': ['foo', 'bar', 'baz']})
 
 
-@patch('wtf.api.weapons.derive')
+@patch('wtf.api.weapons.transform')
 @patch('wtf.api.weapons.find_by_id')
 def test_handle_get_weapon_by_id_request(
         mock_find_by_id,
-        mock_derive,
+        mock_transform,
         test_client
     ):
     mock_find_by_id.return_value = 'foobar'
-    mock_derive.return_value = 'foobar-derived'
+    mock_transform.return_value = 'foobar-transformd'
     response = test_client.get(path='/%s' % TEST_DATA['id'])
     response.assert_status_code(200)
-    response.assert_body({'weapon': 'foobar-derived'})
+    response.assert_body({'weapon': 'foobar-transformd'})
 
 
 def test_handle_get_weapon_by_id_request_not_found(test_client):
@@ -119,7 +119,7 @@ def test_create_weapon_defaults(mock_generate_grade):
     pytest.param(None, None)
 ])
 @patch('wtf.api.weapons.weaponrecipes')
-def test_derive_weapon(mock_weaponrecipes, name, description):
+def test_transform_weapon(mock_weaponrecipes, name, description):
     recipe = TEST_DATA.get('recipe')
     mock_weaponrecipes.find_by_id = Mock(return_value=recipe)
     expected = {
@@ -136,7 +136,7 @@ def test_derive_weapon(mock_weaponrecipes, name, description):
         },
         'other': 'fields'
     }
-    actual = weapons.derive({
+    actual = weapons.transform({
         'recipe': recipe['id'],
         'grade': TEST_DATA['grade'],
         'other': 'fields',

--- a/wtf/testing.py
+++ b/wtf/testing.py
@@ -36,8 +36,8 @@ class Client(object):
         '''Send a POST request'''
         path = '%s%s' % (self.root_path, kwargs.get('path', ''))
         headers = kwargs.get('headers', self.default_headers)
-        body = kwargs.get('body', None)
-        data = json_dumps(body) if body else None
+        body = kwargs.get('body')
+        data = json_dumps(body) if body is not None else None
         response = self.test_client.post(
             path=path,
             headers=headers,


### PR DESCRIPTION
Additionally:
  - Fixed a small bug where you couldn't find a resource by its ID if its ID was a `UUID` object and not a string
  - Moved account transformation stuff (removing the `password` field) into a `transform()` function
  - Renamed `derive()` in `weapons` to `transform()`

Resolves #83